### PR TITLE
Fix building package in Release configurations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,12 @@ import PackageDescription
 
 let package = Package(
     name: "Depends",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15),
+        .tvOS(.v13),
+        .watchOS(.v6)
+    ],
 
     products: [
         .library(name: "Depends-auto", targets: [ "Depends" ]),

--- a/Sources/Depends/Dependency.swift
+++ b/Sources/Depends/Dependency.swift
@@ -1,7 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftNIO open source project
-//
 // Copyright (c) 2021 Unsigned Apps
 // Licensed under MIT License
 //

--- a/Sources/Depends/DependencyBase.swift
+++ b/Sources/Depends/DependencyBase.swift
@@ -1,7 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftNIO open source project
-//
 // Copyright (c) 2021 Unsigned Apps
 // Licensed under MIT License
 //

--- a/Sources/Depends/DependencyKey.swift
+++ b/Sources/Depends/DependencyKey.swift
@@ -1,7 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftNIO open source project
-//
 // Copyright (c) 2021 Unsigned Apps
 // Licensed under MIT License
 //

--- a/Sources/Depends/DependencyProvider.swift
+++ b/Sources/Depends/DependencyProvider.swift
@@ -1,7 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftNIO open source project
-//
 // Copyright (c) 2021 Unsigned Apps
 // Licensed under MIT License
 //

--- a/Sources/Depends/DependencyRegistry+Combine.swift
+++ b/Sources/Depends/DependencyRegistry+Combine.swift
@@ -1,7 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftNIO open source project
-//
 // Copyright (c) 2021 Unsigned Apps
 // Licensed under MIT License
 //

--- a/Sources/Depends/DependencyRegistry.swift
+++ b/Sources/Depends/DependencyRegistry.swift
@@ -1,7 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftNIO open source project
-//
 // Copyright (c) 2021 Unsigned Apps
 // Licensed under MIT License
 //

--- a/Sources/Depends/DependencyRegistryBuilder.swift
+++ b/Sources/Depends/DependencyRegistryBuilder.swift
@@ -1,7 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftNIO open source project
-//
 // Copyright (c) 2021 Unsigned Apps
 // Licensed under MIT License
 //

--- a/Sources/Depends/KeyedDependency.swift
+++ b/Sources/Depends/KeyedDependency.swift
@@ -1,7 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftNIO open source project
-//
 // Copyright (c) 2021 Unsigned Apps
 // Licensed under MIT License
 //

--- a/Sources/Depends/ViewDependency.swift
+++ b/Sources/Depends/ViewDependency.swift
@@ -1,7 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftNIO open source project
-//
 // Copyright (c) 2021 Unsigned Apps
 // Licensed under MIT License
 //

--- a/Sources/TestDepends/BaseTestCase.swift
+++ b/Sources/TestDepends/BaseTestCase.swift
@@ -1,7 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftNIO open source project
-//
 // Copyright (c) 2021 Unsigned Apps
 // Licensed under MIT License
 //

--- a/Sources/TestDepends/TestDependency.swift
+++ b/Sources/TestDepends/TestDependency.swift
@@ -1,7 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftNIO open source project
-//
 // Copyright (c) 2021 Unsigned Apps
 // Licensed under MIT License
 //

--- a/Tests/DependsTests/DependencyRegistryTests.swift
+++ b/Tests/DependsTests/DependencyRegistryTests.swift
@@ -1,7 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftNIO open source project
-//
 // Copyright (c) 2021 Unsigned Apps
 // Licensed under MIT License
 //


### PR DESCRIPTION
Prior to these changes the package would fail to build in Release configurations.

It looks like to import SwiftUI properly a minimum version of iOS 13 is required.

I took the liberty of correcting the file header comments as well.